### PR TITLE
FcDesigner.vue setOption()方法bug

### DIFF
--- a/src/components/FcDesigner.vue
+++ b/src/components/FcDesigner.vue
@@ -513,8 +513,8 @@ export default defineComponent({
                 data.activeRule = null;
                 data.activeTab = 'form';
             },
-            setOption(data) {
-                let option = {...data};
+            setOption(datas) {
+                let option = {...datas};
                 option.form.formCreateSubmitBtn = !!option.submitBtn;
                 option.form.formCreateResetBtn = !!option.resetBtn;
                 option.submitBtn = false;


### PR DESCRIPTION
setOption(data)  data变量同名，导致这个方法会往原始对象里面塞处理后的数据，而不是FcDesigner.vue组件里面的data对象


