### PR TITLE
feat: input组件的属性配置面板增加自定义 on事件

### DIFF
--- a/src/config/rule/input.js
+++ b/src/config/rule/input.js
@@ -15,11 +15,23 @@ export default {
             title: t('components.input.name'),
             info: '',
             $required: false,
-            props: {}
+            props: {},
+            _on:{}
         };
     },
     props(_, {t}) {
-        return localeProps(t, name + '.props', [makeRequiredRule(), {
+        return localeProps(t, name + '.props', [ {
+            type: 'Struct',
+            field: '_on',
+            value: {},
+            title: '自定义on事件',
+            props: {
+              defaultValue: {},
+                validate(val) {
+                    return Object.prototype.toString.call(val) === '[object Object]';
+                }
+            }
+        },makeRequiredRule(),  {
             type: 'select',
             field: 'type',
             title: '类型',


### PR DESCRIPTION
  https://github.com/xaboy/form-create-designer/issues/135   看来用struct组件去实现自定义on事件有些多余，emit属性已经包含了这些能力了吧，我还没理解清楚emit的内容时如何配置出来的，再去研究下~