### PR TITLE
fix: 修复项目启动时报错问题

### DIFF
--- a/packages/ant-design-vue/vue.config.js
+++ b/packages/ant-design-vue/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             filename: 'index.html'
         }
     },
-    transpileDependencies: ['marked'],
+    transpileDependencies: ['marked', 'signature_pad'],
     configureWebpack: {
         module: {
             rules: [

--- a/packages/element-ui/vue.config.js
+++ b/packages/element-ui/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             filename: 'index.html'
         }
     },
-    transpileDependencies: ['marked'],
+    transpileDependencies: ['marked', 'signature_pad'],
     configureWebpack: {
         module: {
             rules: [

--- a/packages/vant/vue.config.js
+++ b/packages/vant/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
             filename: 'index.html'
         }
     },
-    transpileDependencies: ['marked'],
+    transpileDependencies: ['marked', 'signature_pad'],
     configureWebpack: {
         module: {
             rules: [


### PR DESCRIPTION
当执行`pnpm dev:ele`时，会报如下错误。
<img width="1188" height="577" alt="a0aa4f5cc80d02f199625e791ec0e11" src="https://github.com/user-attachments/assets/3be123b2-26b0-49e5-b6d5-11a1d439cf9d" />


原因是引用的npm包：signature_pad它的打包产物的class语法在当前webpack版本中不支持，所以需要转译一下
在vue.conf.js中增加这一行就可以了
```
    transpileDependencies: ['marked', 'signature_pad'],

```